### PR TITLE
BEG-81: Fix indexer id used in error message

### DIFF
--- a/Model/Indexer/Product/ProductIndexer.php
+++ b/Model/Indexer/Product/ProductIndexer.php
@@ -22,7 +22,7 @@ use Magento\Store\Model\StoreDimensionProvider;
 
 class ProductIndexer implements IndexerActionInterface, MviewActionInterface, DimensionalIndexerInterface
 {
-    private const INDEXER_ID = 'catalogsearch_fulltext';
+    private const INDEXER_ID = 'prerender_io_product';
     private const DEPLOYMENT_CONFIG_INDEXER_BATCHES = 'indexer/batch_size/';
 
     /** @var DimensionProviderInterface  */


### PR DESCRIPTION
Shouldn't actually have any effect on functionality, since it's only used in an error message that shouldn't get thrown