### PR TITLE
Add admin configuration to take prerender service url

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -14,7 +14,7 @@ class Config
 {
     private const XML_PATH_RECACHE_ENABLED = 'system/prerender_io/enabled';
     private const XML_PATH_PRERENDER_TOKEN = 'system/prerender_io/token';
-    private const XML_PATH_RECACHE_URL = 'system/prerender_io/url';
+    private const XML_PATH_RECACHE_SERVICE_URL = 'system/prerender_io/service_url';
 
     /** @var ScopeConfigInterface  */
     private ScopeConfigInterface $scopeConfig;
@@ -59,15 +59,15 @@ class Config
     }
 
     /**
-     * Get pre-render url
+     * Get prerender service url
      *
      * @param int|null $storeId
      * @return string|null
      */
-    public function getPreRenderUrl(?int $storeId = null): ?string
+    public function getPrerenderServiceUrl(?int $storeId = null): ?string
     {
         return $this->scopeConfig->getValue(
-            self::XML_PATH_RECACHE_URL,
+            self::XML_PATH_RECACHE_SERVICE_URL,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -4,6 +4,7 @@
  */
 
 declare(strict_types=1);
+
 namespace Aligent\PrerenderIo\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -13,6 +14,7 @@ class Config
 {
     private const XML_PATH_RECACHE_ENABLED = 'system/prerender_io/enabled';
     private const XML_PATH_PRERENDER_TOKEN = 'system/prerender_io/token';
+    private const XML_PATH_RECACHE_URL = 'system/prerender_io/url';
 
     /** @var ScopeConfigInterface  */
     private ScopeConfigInterface $scopeConfig;
@@ -42,7 +44,7 @@ class Config
     }
 
     /**
-     * Return configured Prerender.io token for API calls
+     * Return configured Prerender service token for API calls
      *
      * @param int|null $storeId
      * @return string|null
@@ -51,6 +53,21 @@ class Config
     {
         return $this->scopeConfig->getValue(
             self::XML_PATH_PRERENDER_TOKEN,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+    }
+
+    /**
+     * Get pre-render url
+     *
+     * @param int|null $storeId
+     * @return string|null
+     */
+    public function getPreRenderUrl(?int $storeId = null): ?string
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_RECACHE_URL,
             ScopeInterface::SCOPE_STORE,
             $storeId
         );

--- a/Model/Api/PrerenderClient.php
+++ b/Model/Api/PrerenderClient.php
@@ -81,7 +81,7 @@ class PrerenderClient implements PrerenderClientInterface
      */
     private function sendRequest(array $urls, string $token, ?int $storeId = null): void
     {
-        $preRenderUrl = $this->prerenderConfigHelper->getPrerenderServiceUrl($storeId);
+        $prerenderServiceUrl = $this->prerenderConfigHelper->getPrerenderServiceUrl($storeId);
 
         if (empty($preRenderUrl)) {
             $this->logger->error(
@@ -97,7 +97,7 @@ class PrerenderClient implements PrerenderClientInterface
             ]
         );
         try {
-            $this->client->post($preRenderUrl, $payload);
+            $this->client->post($prerenderServiceUrl, $payload);
         } catch (\Exception $e) {
             $this->logger->error(
                 __('Error sending payload %1 to Prerender service. Store %2', $payload, $storeId),

--- a/Model/Api/PrerenderClient.php
+++ b/Model/Api/PrerenderClient.php
@@ -100,7 +100,7 @@ class PrerenderClient implements PrerenderClientInterface
             $this->client->post($preRenderUrl, $payload);
         } catch (\Exception $e) {
             $this->logger->error(
-                __('Error sending payload %1 to Prerender service', $payload),
+                __('Error sending payload %1 to Prerender service. Store %2', $payload, $storeId),
                 ['exception' => $e]
             );
         }

--- a/Model/Api/PrerenderClient.php
+++ b/Model/Api/PrerenderClient.php
@@ -83,9 +83,9 @@ class PrerenderClient implements PrerenderClientInterface
     {
         $prerenderServiceUrl = $this->prerenderConfigHelper->getPrerenderServiceUrl($storeId);
 
-        if (empty($preRenderUrl)) {
+        if (empty($prerenderServiceUrl)) {
             $this->logger->error(
-                'ERROR: prerender url not found.'
+                __('ERROR: prerender url not found. Store ID: %1', $storeId)
             );
             return;
         }
@@ -100,7 +100,7 @@ class PrerenderClient implements PrerenderClientInterface
             $this->client->post($prerenderServiceUrl, $payload);
         } catch (\Exception $e) {
             $this->logger->error(
-                __('Error sending payload %1 to Prerender service. Store %2', $payload, $storeId),
+                __('Error sending payload %1 to Prerender service. Store ID: %2', $payload, $storeId),
                 ['exception' => $e]
             );
         }

--- a/Model/Api/PrerenderClient.php
+++ b/Model/Api/PrerenderClient.php
@@ -81,7 +81,7 @@ class PrerenderClient implements PrerenderClientInterface
      */
     private function sendRequest(array $urls, string $token, ?int $storeId = null): void
     {
-        $preRenderUrl = $this->prerenderConfigHelper->getPreRenderUrl($storeId);
+        $preRenderUrl = $this->prerenderConfigHelper->getPrerenderServiceUrl($storeId);
 
         if (empty($preRenderUrl)) {
             $this->logger->error(

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # magento2-prerender-io
-Provides integration between Magento 2 and [Prerender.io](https://prerender.io), giving the ability for pages to be automatically recached when required.
+Provides integration between Magento 2 and [Prerender service](https://prerender.io), giving the ability for pages to be automatically recached when required.
 
 ## Overview
 This module provides new indexers:
 
-- `prerender_io_product`, which will send URL recache requests for products to Prerender.io (in batches of up to 1000) when changes are made to products.
-- `prerender_io_category`, which will send URL recache requests for categories to Prerender.io (in batches of up to 1000) when changes are made to categories.
-- `prerender_io_category_product`, which will send URL recache requests for categories to Prerender.io (in batches of up to 1000) when changes are made to products.
+- `prerender_io_product`, which will send URL recache requests for products to Prerender service (in batches of up to 1000) when changes are made to products.
+- `prerender_io_category`, which will send URL recache requests for categories to Prerender service (in batches of up to 1000) when changes are made to categories.
+- `prerender_io_category_product`, which will send URL recache requests for categories to Prerender service (in batches of up to 1000) when changes are made to products.
 
 These will ensure that the cached pages are kept up-to-date at all times.
 
@@ -26,4 +26,4 @@ bin/magento indexer:set-mode schedule prerender_io_product prerender_io_category
 ```
 
 ## Configuration
-The extension can be configured via `Stores -> Configuration -> System -> Prerender.io`
+The extension can be configured via `Stores -> Configuration -> System -> Prerender service`

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aligent/magento2-prerender-io",
-    "description": "Prerender.io integration for Magento 2, providing recaching for product URLs",
+    "description": "Prerender service integration for Magento 2, providing recaching for product URLs",
     "require": {
         "php": ">=7.4",
         "magento/framework": "*"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -16,6 +16,9 @@
                 </field>
                 <field id="service_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Service URL</label>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
                 </field>
                 <field id="token" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Token</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -14,8 +14,8 @@
                     <comment>Send recache requests to Prerender service on product changes</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>Price By SKU</label>
+                <field id="service_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Service URL</label>
                 </field>
                 <field id="token" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Token</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -8,13 +8,16 @@
     <system>
         <section id="system">
             <group id="prerender_io" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="100">
-                <label>Prerender.io</label>
+                <label>Prerender service</label>
                 <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Product recaching enabled?</label>
-                    <comment>Send recache requests to Prerender.io on product changes</comment>
+                    <comment>Send recache requests to Prerender service on product changes</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="token" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Price By SKU</label>
+                </field>
+                <field id="token" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Token</label>
                     <depends>
                         <field id="enabled">1</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <system>
+            <prerender_io>
+                <enabled>0</enabled>
+                <url><![CDATA[https://api.prerender.io/recache]]></url>
+            </prerender_io>
+        </system>
+    </default>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,7 +5,7 @@
         <system>
             <prerender_io>
                 <enabled>0</enabled>
-                <url><![CDATA[https://api.prerender.io/recache]]></url>
+                <service_url><![CDATA[https://api.prerender.io/recache]]></service_url>
             </prerender_io>
         </system>
     </default>

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -5,15 +5,15 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Indexer/etc/indexer.xsd">
     <indexer id="prerender_io_product" view_id="prerender_io_product" class="Aligent\PrerenderIo\Model\Indexer\Product\ProductIndexer">
-        <title translate="true">Prerender.io Product Recaching</title>
+        <title translate="true">Prerender service Product Recaching</title>
         <description translate="true">Recaches product urls when products are updated</description>
     </indexer>
     <indexer id="prerender_io_category" view_id="prerender_io_category" class="Aligent\PrerenderIo\Model\Indexer\Category\CategoryIndexer">
-        <title translate="true">Prerender.io Category Recaching</title>
+        <title translate="true">Prerender service Category Recaching</title>
         <description translate="true">Recaches category urls when categories are updated</description>
     </indexer>
     <indexer id="prerender_io_category_product" view_id="prerender_io_category_product" class="Aligent\PrerenderIo\Model\Indexer\Category\ProductIndexer">
-        <title translate="true">Prerender.io Category Product Recaching</title>
+        <title translate="true">Prerender service Category Product Recaching</title>
         <description translate="true">Recaches category urls when products are updated</description>
     </indexer>
 </config>


### PR DESCRIPTION
- Added below admin configuration to manage the pretender service URL
- Default service URL is https://api.prerender.io/recache
- In default module is disabled

![image](https://github.com/aligent/magento2-prerender-io/assets/77260133/0ed05571-e3ac-43f2-8797-ef62c8efe5e5)


![corasol_pre-render_set](https://github.com/aligent/magento2-prerender-io/assets/77260133/38182262-1430-439a-a6e9-2398ae210846)
